### PR TITLE
Require document start and end delimiters

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -14,31 +14,27 @@ class Parser
      */
     public function parse(string $content): array
     {
-        if ('' === trim($content)) {
+        $content = trim($content);
+        if ('' === $content) {
             return [];
         }
 
-        $parsedDocuments = [];
-        $lines = explode("\n", $content);
-        $lineCount = count($lines);
-
-        $currentLines = [];
-
-        foreach ($lines as $lineIndex => $line) {
-            $isDocumentStart = self::DOCUMENT_START === $line;
-            $isDocumentEnd = self::DOCUMENT_END === $line;
-            $isLastLine = $lineIndex === $lineCount - 1;
-
-            if (false === $isDocumentStart && false === $isDocumentEnd) {
-                $currentLines[] = $line;
-            }
-
-            if (($isDocumentStart || $isLastLine) && [] !== $currentLines) {
-                $parsedDocuments[] = implode("\n", $currentLines);
-                $currentLines = [];
-            }
+        if (
+            false === str_starts_with($content, self::DOCUMENT_START . "\n")
+            || false === str_ends_with($content, "\n" . self::DOCUMENT_END)
+        ) {
+            return [];
         }
 
-        return $parsedDocuments;
+        $documents = explode(self::DOCUMENT_START . "\n", $content);
+        array_shift($documents);
+
+        array_walk($documents, function (&$document) {
+            $document = rtrim($document);
+            $document = rtrim($document, '.');
+            $document = rtrim($document);
+        });
+
+        return $documents;
     }
 }

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -36,21 +36,21 @@ class ParserTest extends TestCase
             ],
             'single document, no start or end delimiters' => [
                 'content' => $content[0],
-                'expected' => [$content[0]],
+                'expected' => [],
             ],
             'single document, start delimiter only' => [
                 'content' => <<< EOF
                 ---
                 {$content[0]}
                 EOF,
-                'expected' => [$content[0]],
+                'expected' => [],
             ],
             'single document, end delimiter only' => [
                 'content' => <<< EOF
                 {$content[0]}
                 ...
                 EOF,
-                'expected' => [$content[0]],
+                'expected' => [],
             ],
             'single document, start and end delimiters' => [
                 'content' => <<< EOF
@@ -67,7 +67,7 @@ class ParserTest extends TestCase
                 ---
                 {$content[1]}
                 EOF,
-                'expected' => [$content[0], $content[1]],
+                'expected' => [],
             ],
             'two documents, start and end delimiters' => [
                 'content' => <<< EOF


### PR DESCRIPTION
Fixes #28